### PR TITLE
feat(popup): add emoji picker with search for emoji_* fields

### DIFF
--- a/src/emoji.js
+++ b/src/emoji.js
@@ -1,0 +1,148 @@
+(function () {
+  // Lightweight emoji data provider for the popup
+  // - Combines a curated set (with names) and a generated set from Unicode ranges
+  // - Exposes window.EmojiData with { list, search(query, limit) }
+
+  const curated = [
+    { char: "✅", name: "check success done pass ok green checkmark" },
+    { char: "❌", name: "cross fail error x cancel stop" },
+    { char: "⚠️", name: "warning caution alert attention" },
+    { char: "⏳", name: "hourglass waiting rate limited time" },
+    { char: "🔒", name: "lock private secret restricted" },
+    { char: "🔓", name: "unlock public open" },
+    { char: "🟢", name: "green circle active online" },
+    { char: "🔴", name: "red circle inactive offline" },
+    { char: "🟡", name: "yellow circle pending caution" },
+    { char: "🟠", name: "orange circle warning" },
+    { char: "🟣", name: "purple circle" },
+    { char: "🔵", name: "blue circle info" },
+    { char: "⚪", name: "white circle" },
+    { char: "⚫", name: "black circle" },
+    { char: "🟩", name: "green square" },
+    { char: "🟥", name: "red square" },
+    { char: "🟨", name: "yellow square" },
+    { char: "🟦", name: "blue square" },
+    { char: "🚀", name: "rocket launch fast ship" },
+    { char: "🐛", name: "bug issue defect" },
+    { char: "🧪", name: "test experiment lab" },
+    { char: "✨", name: "sparkles feature new shiny" },
+    { char: "♻️", name: "recycle refactor cleanup" },
+    { char: "🔧", name: "wrench fix tool" },
+    { char: "🛠️", name: "tools build maintenance" },
+    { char: "📦", name: "package release ship" },
+    { char: "📝", name: "memo note docs documentation" },
+    { char: "🚨", name: "alarm breaking urgent" },
+    { char: "🔥", name: "fire hot important" },
+    { char: "🌟", name: "star favorite highlight" },
+    { char: "⭐", name: "star rating" },
+    { char: "📈", name: "chart up growth increase" },
+    { char: "📉", name: "chart down decrease" },
+    { char: "⬆️", name: "up increase upgrade" },
+    { char: "⬇️", name: "down decrease downgrade" },
+    { char: "🔀", name: "merge shuffle" },
+    { char: "🔃", name: "refresh sync cycle" },
+    { char: "🔁", name: "repeat again retry" },
+    { char: "🔂", name: "repeat once" },
+    { char: "🔄", name: "cycle reload" },
+    { char: "👀", name: "eyes review look" },
+    { char: "🤖", name: "bot automation robot" },
+    { char: "🧠", name: "brain smart ai" },
+    { char: "🧩", name: "puzzle piece component" },
+    { char: "📌", name: "pin important" },
+    { char: "📍", name: "pin location" },
+    { char: "🏷️", name: "label tag" },
+    { char: "🏁", name: "finish flag done" },
+    { char: "🎯", name: "target goal focus" },
+    { char: "🧵", name: "thread discussion" },
+    { char: "🔗", name: "link url" },
+    { char: "🗑️", name: "trash delete remove" },
+    { char: "🧹", name: "broom cleanup clean" },
+    { char: "📥", name: "inbox import" },
+    { char: "📤", name: "outbox export" },
+    { char: "🕒", name: "clock time waiting" },
+    { char: "⏱️", name: "stopwatch timer" },
+    { char: "🔍", name: "search find" },
+    { char: "🔎", name: "search zoom" },
+    { char: "💡", name: "idea lightbulb suggestion" },
+    { char: "📚", name: "books knowledge" },
+    { char: "🔒", name: "lock private secure" },
+    { char: "🔓", name: "unlock public" },
+    { char: "🚧", name: "construction wip" },
+    { char: "🧯", name: "extinguisher safety" }
+  ];
+
+  function uniqByChar(arr) {
+    const seen = new Set();
+    const out = [];
+    for (const it of arr) {
+      if (!seen.has(it.char)) {
+        seen.add(it.char);
+        out.push(it);
+      }
+    }
+    return out;
+  }
+
+  function generateFromRanges() {
+    // Broad emoji-heavy ranges
+    const ranges = [
+      [0x1F300, 0x1F5FF], // Misc Symbols and Pictographs
+      [0x1F600, 0x1F64F], // Emoticons
+      [0x1F680, 0x1F6FF], // Transport & Map
+      [0x2600,  0x26FF],  // Misc symbols
+      [0x2700,  0x27BF],  // Dingbats
+      [0x1F900, 0x1F9FF], // Supplemental Symbols and Pictographs
+      [0x1FA70, 0x1FAFF]  // Symbols & Pictographs Extended-A
+    ];
+
+    const list = [];
+    let testRe = null;
+    try {
+      // Prefer Extended_Pictographic for better coverage
+      testRe = /\p{Extended_Pictographic}/u;
+    } catch (_) {
+      try { testRe = /\p{Emoji_Presentation}/u; } catch (_) { testRe = null; }
+    }
+
+    for (const [start, end] of ranges) {
+      for (let cp = start; cp <= end; cp++) {
+        const ch = String.fromCodePoint(cp);
+        if (!testRe || testRe.test(ch)) list.push({ char: ch, name: "" });
+      }
+    }
+    return list;
+  }
+
+  const generated = generateFromRanges();
+  const list = uniqByChar([...curated, ...generated]);
+
+  function search(query, limit = 250) {
+    const q = (query || "").trim().toLowerCase();
+    if (!q) return list.slice(0, limit);
+
+    // If query is hex like 1f600 or u+1f600, match by codepoint
+    const hex = q.replace(/^u\+/, "");
+    const isHex = /^[0-9a-f]{3,6}$/i.test(hex);
+
+    const results = [];
+    for (const item of list) {
+      if (results.length >= limit) break;
+      if (!q) { results.push(item); continue; }
+
+      if (item.name && item.name.includes(q)) { results.push(item); continue; }
+      if (item.char === query) { results.push(item); continue; }
+
+      if (isHex) {
+        const cps = Array.from(item.char).map(c => c.codePointAt(0)?.toString(16)).filter(Boolean);
+        if (cps.some(h => h === hex)) { results.push(item); continue; }
+      }
+    }
+    return results;
+  }
+
+  window.EmojiData = {
+    list,
+    search
+  };
+})();
+

--- a/src/popup.html
+++ b/src/popup.html
@@ -27,6 +27,7 @@
     <button id="clearBtn">Reset</button>
   </div>
 
+  <script src="emoji.js"></script>
   <script src="popup.js"></script>
   <script src="compat.js"></script>
   <script src="config.js"></script>

--- a/src/popup.js
+++ b/src/popup.js
@@ -50,6 +50,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     formGroup.style.alignItems = "center";
     formGroup.style.justifyContent = "space-between";
     formGroup.style.flexDirection = "row";
+    formGroup.style.position = "relative";
 
     // Label
     const label = document.createElement("label");
@@ -83,6 +84,86 @@ document.addEventListener("DOMContentLoaded", async () => {
 
     formGroup.appendChild(label);
     formGroup.appendChild(input);
+
+    // Emoji picker for emoji_* fields
+    if (key.startsWith("emoji_")) {
+      const trigger = document.createElement("button");
+      trigger.type = "button";
+      trigger.className = "emoji-btn emoji-trigger";
+      trigger.textContent = input.value && input.value.trim() ? input.value : "😀";
+      Object.assign(trigger.style, {
+        width: "auto",
+        display: "inline-flex",
+        marginTop: "0",
+        marginLeft: "8px",
+        padding: "6px 8px",
+        flex: "0 0 auto",
+        alignItems: "center",
+        justifyContent: "center"
+      });
+
+      const picker = document.createElement("div");
+      picker.className = "emoji-picker";
+      picker.style.display = "none";
+
+      const searchWrap = document.createElement("div");
+      searchWrap.className = "emoji-search-wrap";
+      const search = document.createElement("input");
+      search.type = "text";
+      search.placeholder = "Search emoji...";
+      search.className = "emoji-search";
+      searchWrap.appendChild(search);
+
+      const grid = document.createElement("div");
+      grid.className = "emoji-grid";
+
+      picker.appendChild(searchWrap);
+      picker.appendChild(grid);
+      formGroup.appendChild(trigger);
+      formGroup.appendChild(picker);
+
+      function openPicker() {
+        picker.style.display = "block";
+        renderGrid("");
+        search.focus();
+        document.addEventListener("click", outsideClose, { capture: true });
+      }
+      function closePicker() {
+        picker.style.display = "none";
+        document.removeEventListener("click", outsideClose, { capture: true });
+      }
+      function togglePicker() {
+        if (picker.style.display === "none") openPicker(); else closePicker();
+      }
+      function outsideClose(e) {
+        if (!picker.contains(e.target) && e.target !== trigger) {
+          closePicker();
+        }
+      }
+      function renderGrid(q) {
+        grid.innerHTML = "";
+        const data = (window.EmojiData && typeof window.EmojiData.search === "function")
+          ? window.EmojiData.search(q, 250)
+          : [];
+        data.forEach(item => {
+          const btn = document.createElement("button");
+          btn.type = "button";
+          btn.className = "emoji-choice";
+          btn.title = item.name || "";
+          btn.textContent = item.char;
+          btn.addEventListener("click", () => {
+            input.value = item.char;
+            trigger.textContent = item.char;
+            closePicker();
+          });
+          grid.appendChild(btn);
+        });
+      }
+
+      trigger.addEventListener("click", (e) => { e.stopPropagation(); togglePicker(); });
+      search.addEventListener("input", () => renderGrid(search.value));
+    }
+
     formGroup.appendChild(toggle);
 
     formsContainer.appendChild(formGroup);

--- a/src/style.css
+++ b/src/style.css
@@ -184,3 +184,64 @@ button:hover { background: var(--button-hover-bg); }
 .clearBtn {
   background-color: rgb(180, 53, 53);
 }
+
+/* -----------------------------------
+   EMOJI PICKER
+----------------------------------- */
+.emoji-btn {
+  width: auto !important;
+  margin-top: 0 !important;
+  background: var(--button-bg);
+  color: #fff;
+  border-radius: 6px;
+  padding: 6px 8px;
+}
+
+.emoji-picker {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 6px);
+  width: 260px;
+  background: var(--card-bg);
+  border: 1px solid var(--input-border);
+  border-radius: 10px;
+  box-shadow: 0 8px 20px rgba(0,0,0,0.35);
+  padding: 8px;
+  z-index: 10000;
+}
+
+.emoji-search {
+  width: 100%;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--input-border);
+  outline: none;
+  background: var(--input-bg);
+  color: var(--card-text);
+  margin-bottom: 8px;
+}
+
+.emoji-grid {
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  gap: 4px;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.emoji-choice {
+  width: auto !important;
+  margin-top: 0 !important;
+  padding: 6px !important;
+  border-radius: 6px !important;
+  background: transparent !important;
+  border: 1px solid transparent !important;
+  color: var(--card-text) !important;
+  font-size: 18px !important;
+  line-height: 1 !important;
+}
+
+.emoji-choice:hover {
+  border-color: var(--input-border) !important;
+  background: var(--input-bg) !important;
+}


### PR DESCRIPTION
Adds a searchable emoji selector to the config popup for all emoji_* fields.

- New module src/emoji.js with curated + generated emoji list and name/codepoint search.\n- popup.js: injects trigger button and picker UI (search input, grid, outside click to close); selection writes to the associated input.\n- style.css: scoped styles for .emoji-picker, .emoji-search, .emoji-grid, and button overrides so controls don’t stretch.\n- popup.html: loads emoji.js before popup.js.

No external deps; offline-friendly. Picker limits grid to ~250 results for responsiveness; uses Unicode ranges + Extended_Pictographic fallback.